### PR TITLE
Updated abilities for the Harpy, Balloonist, Lycanthrope & Legion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Version 2.3.2
 - Harpy (Minion), Ability - "Each night, choose 2 players: tomorrow, the 1st player is mad that the 2nd is evil, or one or both might die."
 - Balloonist (Townsfolk), Ability - "Each night, you learn a player of a different character type than last night. [+0 or +1 Outsider]"
-- Added Storyteller reminder into the Lycanthrope ability; a Demon still wakes and chooses if applicable, but they'd don't cause a death if they would.
+- Added Storyteller reminder into the Lycanthrope ability; a Demon still wakes and chooses if applicable, but they don't cause a death if they normally would.
 - Added Storyteller reminder to the Legion night sheet - "Most nights, kill a Legion. Your aim is to get to three players; two good players and one Legion player. On the final day, if the players don't execute, kill a good player that night so that evil wins."
 
 ### Version 2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - but their name on your token, to the right of your arrow (who I am pointing at)
 - add +1 to the target players "being pointed at" count, which is also displayed to the left of the arrow
 
+### Version 2.3.2
+- Harpy (Minion), Ability - "Each night, choose 2 players: tomorrow, the 1st player is mad that the 2nd is evil, or one or both might die."
+- Balloonist (Townsfolk), Ability - "Each night, you learn a player of a different character type than last night. [+0 or +1 Outsider]"
+- Added Storyteller reminder into the Lycanthrope ability; a Demon still wakes and chooses if applicable, but they'd don't cause a death if they would.
+- Added Storyteller reminder to the Legion night sheet - "Most nights, kill a Legion. Your aim is to get to three players; two good players and one Legion player. On the final day, if the players don't execute, kill a good player that night so that evil wins."
+
 ### Version 2.3.1
 - Updated Riot (Demon)
 -- Ability was: "Nominees die, but may nominate again immediately (on day 3, they must). After day 3, evil wins. [All Minions are Riot]"
@@ -22,7 +28,6 @@
 
 - Updated Lycanthrope (Townsfolk)
 -- Ability was: "Each night*, choose an alive player: If good, they die & the Demon doesn't kill tonight."
-
 -- Ability is: "Each night*, choose an alive player: If good, they die & the Demon doesn't kill tonight. One good player registers as evil."
 
 ### Version 2.3

--- a/src/roles.json
+++ b/src/roles.json
@@ -1257,14 +1257,14 @@
     "firstNight": 45,
     "firstNightReminder": "Choose a character type. Point to a player whose character is of that type. Place the Balloonist's Seen reminder next to that character.",
     "otherNight": 62,
-    "otherNightReminder": "Choose a character type that does not yet have a Seen reminder next to a character of that type. Point to a player whose character is of that type, if there are any. Place the Balloonist's Seen reminder next to that character.",
+    "otherNightReminder": "Choose a player whose character type is different to the currennt Seen reminder token. Remove the previous Seen token and place a corresponding token for the chosen player.",
     "reminders": ["Seen Townsfolk",
         "Seen Outsider",
         "Seen Minion",
         "Seen Demon",
         "Seen Traveller"],
     "setup": true,
-    "ability": "Each night, you learn 1 player of each character type, until there are no more types to learn. [+1 Outsider]"
+    "ability": "Each night, you learn a player of a different character type than last night. [+0 or +1 Outsider]"
   },
   {
     "id": "cultleader",
@@ -1287,7 +1287,7 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 22,
-    "otherNightReminder": "The Lycanthrope points to a living player: if good, they die & the Demon doesn't kill tonight",
+    "otherNightReminder": "The Lycanthrope points to a living player: if good, they die & the Demon doesn't kill tonight (but does wake as normal).",
     "reminders": ["Dead","Registers Evil"],
     "setup": false,
     "ability": "Each night*, choose an alive player: If good, they die & the Demon doesn't kill tonight. One good player registers as evil."
@@ -1840,10 +1840,10 @@
     "firstNight": 17,
     "firstNightReminder": "The Harpy points to one player, then another player. Mark the first player with the “Mad” reminder and the second player with the “2nd” reminder. Put the Harpy to sleep. Wake the player marked “Mad”. Show the “This Character Selected You” info token then the Harpy token, then point to the player marked “2nd”. Put the player marked “Mad” to sleep.",
     "otherNight": 8,
-    "otherNightReminder": "Tomorrow, if the player marked “mad” is not mad that the player marked “2nd” is evil, you may kill both players.",
+    "otherNightReminder": "Tomorrow, if the player marked “mad” is not mad that the player marked “2nd” is evil, you may kill one or both players.",
     "reminders": ["Mad", "2nd"],
     "setup": false,
-    "ability": "Each night, choose 2 players: tomorrow, the 1st player is mad that the 2nd is evil, or both might die."
+    "ability": "Each night, choose 2 players: tomorrow, the 1st player is mad that the 2nd is evil, or one or both might die."
   },
   {
     "id": "summoner",
@@ -1949,7 +1949,7 @@
     "firstNight": 0,
     "firstNightReminder": "",
     "otherNight": 23,
-    "otherNightReminder": "Choose a player, that player dies.",
+    "otherNightReminder": "Most nights, kill a Legion. Your aim is to get to three players; two good players and one Legion player. On the final day, if the players don't execute, kill a good player that night so that evil wins.",
     "reminders": ["Dead",
         "About to die"],
     "setup": true,


### PR DESCRIPTION
- Harpy (Minion), Ability - "Each night, choose 2 players: tomorrow, the 1st player is mad that the 2nd is evil, or one or both might die."

- Balloonist (Townsfolk), Ability - "Each night, you learn a player of a different character type than last night. [+0 or +1 Outsider]"

- Added Storyteller reminder into the Lycanthrope ability; a Demon still wakes and chooses if applicable, but they'd don't cause a death if they would.

- Added Storyteller reminder to the Legion night sheet - "Most nights, kill a Legion. Your aim is to get to three players; two good players and one Legion player. On the final day, if the players don't execute, kill a good player that night so that evil wins."