### PR TITLE
[NEW] Alignment Toggle on Player Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,40 @@
 ### Ideas
 - Add a set of emotes that come from a players seated position
 -- probably disable emotes during an active votes/other important activites
-- Alignment change - hue colours to the new alignment
 - Evil Victory & Good Victory celebration animations?
+
+### Version 2.25.2
+- Added a button for the Storyteller and players to toggle the alignment of players.
+
+- Good/Evil Alignment Toggle (new feature)
+-- Seated players and the Storyteller can now privately annotate player alignment during a game.
+
+- Storyteller view
+-- A small circle button appears on each player token (top-right, matching the Night Order circle sizing and responsive scaling).
+-- Clicking cycles alignment: Townsfolk/Outsider toggle evil → null; Minion/Demon toggle good → null; Traveler cycles good → evil → null.
+-- A colour overlay (mix-blend-mode: color) tints the token blue (good) or red (evil).
+-- ST alignment state is stored in Vuex and not transmitted via socket.
+
+- Seated player view
+-- Alignment buttons are visible on all player tokens — clicking records a private, local-only annotation for that token.
+-- Annotations are stored in localStorage keyed by localAlignment_{playerId}_{targetPlayerId} — never transmitted through the socket.
+-- Own token button is always visible; other tokens' buttons appear only when annotated (good/evil set), or on hover when neutral.
+-- When a seated player has annotated their own token, the radiant pulsing glow behind their character token overrides the team colour: good → townsfolk blue, evil → demon red.
+
+- Raise-hand button
+-- The clickable raise-hand circle is hidden for seated players on other players' tokens.
+-- The raised-hand image itself remains visible across all clients when a player raises their hand.
+-- The ST can still click the button on behalf of any player.
+
+- Build / Cross-platform Fix
+-- Added cross-env devDependency so NODE_OPTIONS=--openssl-legacy-provider works on Windows without NODE_OPTIONS syntax errors.
+
+- Bug Fixes:
+-- String.substr() → String.slice() (deprecation) in socket.js.
+-- Night Order circles and raise-hand emote raised to z-index: 5 to render above the alignment colour overlay.
+-- Player context menu z-index: 50 — no longer drops behind other player tokens on hover.
+-- TownSquare.vue emote em raised to z-index: 5.
+-- Alignment button responsive sizing added to media.scss at <1200px and <992px breakpoints, matching the Night Order circle dimensions exactly.
 
 ### Version 2.25.1
 - Fixed: When you toggle to "Show" mode [G], a seated player could not point-vote.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "townsquare",
-  "version": "2.16.0",
+  "version": "2.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "townsquare",
-      "version": "2.16.0",
+      "version": "2.40.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.32",
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@vue/cli-plugin-eslint": "^4.5.9",
         "@vue/eslint-config-prettier": "^6.0.0",
+        "cross-env": "^10.1.0",
         "eslint": "^6.7.2",
         "eslint-plugin-prettier": "^3.2.0",
         "eslint-plugin-vue": "^6.2.2",
@@ -62,6 +63,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "0.2.35",
@@ -2799,6 +2807,88 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-env/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-env/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-env/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/cross-spawn": {
@@ -8452,6 +8542,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "devOptional": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Blood on the Clocktower Town Square",
   "author": "Steffen Baumgart",
   "scripts": {
-    "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
-    "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build ./src/main.js",
+    "serve": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
+    "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build ./src/main.js",
     "lint": "vue-cli-service lint",
     "lint-ci": "vue-cli-service lint --no-fix --max-warnings=0"
   },
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@vue/cli-plugin-eslint": "^4.5.9",
     "@vue/eslint-config-prettier": "^6.0.0",
+    "cross-env": "^10.1.0",
     "eslint": "^6.7.2",
     "eslint-plugin-prettier": "^3.2.0",
     "eslint-plugin-vue": "^6.2.2",

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -367,6 +367,10 @@ export default {
     clearRoles() {
       if (confirm("Are you sure you want to remove all player roles?")) {
         this.$store.dispatch("players/clearRoles");
+        this.$store.commit("players/resetAllAlignments");
+        Object.keys(localStorage)
+          .filter(k => k.startsWith("localAlignment_"))
+          .forEach(k => localStorage.removeItem(k));
       }
     },
     toggleNight() {

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -1,5 +1,5 @@
 <template>
-  <li :style="zoom">
+  <li :style="zoom" :class="{ 'menu-open': isMenuOpen }">
     <div
       ref="player"
       class="player"
@@ -13,7 +13,9 @@
           'vote-lock': voteLocked,
           'hidden-voting': session.isHiddenVoting,
           'hand-raised': player.handRaised,
-          'point-vote-leader': isPointVoteLeader
+          'point-vote-leader': isPointVoteLeader,
+          'glow-good': session.isSpectator && player.id === session.playerId && selfAlignment === 'good',
+          'glow-evil': session.isSpectator && player.id === session.playerId && selfAlignment === 'evil'
         },
         player.role.team
       ]"
@@ -43,13 +45,27 @@
         }}</span>
       </div>
 
-      <div class="emote" @click="toggleHandRaised()">
+      <div class="emote" v-if="!session.isSpectator || player.id === session.playerId" @click="toggleHandRaised()">
         <em>
           <font-awesome-icon icon="hand-paper" size="xs" />
         </em>
       </div>
 
       <Token :role="player.role" @set-role="onTokenClick" />
+
+      <!-- Alignment overlay (ST view: ST-set alignment; player view: self-set alignment) -->
+      <div
+        v-if="displayedAlignment"
+        class="alignment-overlay"
+        :class="displayedAlignment"
+      ></div>
+
+      <!-- Alignment toggle button -->
+      <div
+        class="alignment-btn"
+        :class="displayedAlignment || 'unset'"
+        @click.stop="cycleCurrentAlignment"
+      ></div>
 
       <!-- Overlay icons -->
       <div class="overlay">
@@ -282,6 +298,10 @@ export default {
         )
         .filter(Boolean);
     },
+    displayedAlignment() {
+      if (!this.session.isSpectator) return this.player.alignment || null;
+      return this.selfAlignment;
+    },
     isPointVoteLeader() {
       return (
         (this.session.pointVoteActive || this.session.pointVoteEnded) &&
@@ -336,10 +356,51 @@ export default {
   },
   data() {
     return {
-      isMenuOpen: false
+      isMenuOpen: false,
+      selfAlignment: null
     };
   },
+  mounted() {
+    const key = `localAlignment_${this.session.playerId}_${this.player.id}`;
+    this.selfAlignment = localStorage.getItem(key) || null;
+  },
   methods: {
+    cycleCurrentAlignment() {
+      if (!this.session.isSpectator) {
+        this.cycleAlignment();
+      } else {
+        this.cycleSelfAlignment();
+      }
+    },
+    alignmentCycleNext(current) {
+      const team = this.player.role.team;
+      if (team === "traveler") {
+        // full cycle: null → good → evil → null
+        if (current === null) return "good";
+        if (current === "good") return "evil";
+        return null;
+      }
+      const baseEvil = team === "minion" || team === "demon";
+      const opposite = baseEvil ? "good" : "evil";
+      // two-step cycle: null → opposite → null
+      return current === null ? opposite : null;
+    },
+    cycleAlignment() {
+      this.updatePlayer(
+        "alignment",
+        this.alignmentCycleNext(this.player.alignment)
+      );
+    },
+    cycleSelfAlignment() {
+      const next = this.alignmentCycleNext(this.selfAlignment);
+      this.selfAlignment = next;
+      const key = `localAlignment_${this.session.playerId}_${this.player.id}`;
+      if (next) {
+        localStorage.setItem(key, next);
+      } else {
+        localStorage.removeItem(key);
+      }
+    },
     changePronouns() {
       if (this.session.isSpectator && this.player.id !== this.session.playerId)
         return;
@@ -471,6 +532,10 @@ export default {
 
 <style lang="scss">
 @import "../vars.scss";
+
+.circle > li.menu-open {
+  z-index: 50 !important;
+}
 
 .fold-enter-active,
 .fold-leave-active {
@@ -663,6 +728,87 @@ export default {
   }
 }
 
+/***** Alignment button ******/
+.player .alignment-btn {
+  position: absolute;
+  width: 31px;
+  height: 31px;
+  border-radius: 50%;
+  right: -3%;
+  bottom: -10%;
+  top: 12.5%;
+  border: 2.5px solid black;
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.5));
+  cursor: pointer;
+  z-index: 5;
+  pointer-events: all;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: background 300ms ease;
+
+  &.unset {
+    background: linear-gradient(180deg, #555 0%, #888 100%);
+    opacity: 0.5;
+  }
+
+  &.good {
+    background: linear-gradient(180deg, #1a5fd4 0%, #4da6ff 100%);
+    opacity: 1;
+  }
+
+  &.evil {
+    background: linear-gradient(180deg, #a00 0%, #e03030 100%);
+    opacity: 1;
+  }
+
+  #townsquare.public & {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+// Spectator view: own token button always visible; other tokens only on hover when unset
+#townsquare.spectator .player:not(.you) .alignment-btn.unset {
+  opacity: 0;
+}
+#townsquare.spectator li:hover .player:not(.you) .alignment-btn.unset {
+  opacity: 0.4;
+}
+
+/***** Alignment overlay ******/
+.player .alignment-overlay {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  border-radius: 50%;
+  pointer-events: none;
+  mix-blend-mode: color;
+  z-index: 3;
+  transition: background-color 400ms ease, transform 200ms ease-in-out;
+  transform: perspective(400px) rotateY(0deg);
+  backface-visibility: hidden;
+
+  &:before {
+    content: " ";
+    display: block;
+    padding-top: 100%;
+  }
+
+  &.good {
+    background: rgba(40, 110, 255, 0.85);
+  }
+
+  &.evil {
+    background: rgba(220, 40, 40, 0.85);
+  }
+}
+
+#townsquare.public .circle .alignment-overlay {
+  transform: perspective(400px) rotateY(-180deg);
+}
+
 /***** Role token ******/
 .player .token {
   position: absolute;
@@ -817,6 +963,14 @@ li.move:not(.from) .player .overlay svg.move {
   animation: townsfolk-glow 5s ease-in-out infinite;
 }
 
+// Alignment override: seated player's self-alignment overrides team glow
+.player.you.glow-good .token {
+  animation: townsfolk-glow 5s ease-in-out infinite !important;
+}
+.player.you.glow-evil .token {
+  animation: demon-glow 5s ease-in-out infinite !important;
+}
+
 /****** Marked icon ******/
 .player .marked {
   position: absolute;
@@ -966,6 +1120,7 @@ li.move:not(.from) .player .overlay svg.move {
   margin-left: 15px;
   cursor: pointer;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+  z-index: 50;
 
   &:before {
     content: " ";
@@ -1007,7 +1162,7 @@ li.move:not(.from) .player .overlay svg.move {
 
 /**** Night reminders ****/
 .player .night-order {
-  z-index: 3;
+  z-index: 5;
 }
 
 .player.dead .night-order em {

--- a/src/components/PointVote.vue
+++ b/src/components/PointVote.vue
@@ -19,9 +19,9 @@
                 leaderVoteCount !== 1 ? "s" : ""
               }}</span
             >
-            <span class="result-voters">Voters: {{
-              votersForPlayer(leaderIdx).join(", ")
-            }}</span>
+            <span class="result-voters"
+              >Voters: {{ votersForPlayer(leaderIdx).join(", ") }}</span
+            >
           </div>
         </template>
         <template v-if="!session.isSpectator">

--- a/src/components/TownSquare.vue
+++ b/src/components/TownSquare.vue
@@ -703,7 +703,7 @@ export default {
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 3;
+    z-index: 5;
   }
 }
 

--- a/src/components/modals/RolesModal.vue
+++ b/src/components/modals/RolesModal.vue
@@ -149,6 +149,10 @@ export default {
             });
           }
         });
+        this.$store.commit("players/resetAllAlignments");
+        Object.keys(localStorage)
+          .filter(k => k.startsWith("localAlignment_"))
+          .forEach(k => localStorage.removeItem(k));
         this.$store.commit("toggleModal", "roles");
       }
     },

--- a/src/components/modals/VoteHistoryModal.vue
+++ b/src/components/modals/VoteHistoryModal.vue
@@ -104,7 +104,9 @@ export default {
     setRecordVoteHistory() {
       if (this._toggleCooldown) return;
       this._toggleCooldown = true;
-      setTimeout(() => { this._toggleCooldown = false; }, 1000);
+      setTimeout(() => {
+        this._toggleCooldown = false;
+      }, 1000);
       this.$store.commit(
         "session/setVoteHistoryAllowed",
         !this.session.isVoteHistoryAllowed

--- a/src/media.scss
+++ b/src/media.scss
@@ -13,6 +13,10 @@
     width: 25px;
     height: 25px;
   }
+  .player .alignment-btn {
+    width: 25px;
+    height: 25px;
+  }
   .fabled .night-order.first span {
     left: 30px;
   }
@@ -32,6 +36,10 @@
     height: 20px;
   }
   .emote em {
+    width: 25px;
+    height: 25px;
+  }
+  .player .alignment-btn {
     width: 25px;
     height: 25px;
   }

--- a/src/store/modules/players.js
+++ b/src/store/modules/players.js
@@ -6,7 +6,8 @@ const NEWPLAYER = {
   isVoteless: false,
   isDead: false,
   pronouns: "",
-  handRaised: false
+  handRaised: false,
+  alignment: null
 };
 
 const state = () => ({
@@ -102,6 +103,12 @@ const mutations = {
   },
   set(state, players = []) {
     state.players = players;
+  },
+  resetAllAlignments(state) {
+    state.players.forEach(player => {
+      player.alignment = null;
+    });
+    state.players.splice(0, 0);
   },
   /**
   The update mutation also has a property for isFromSockets

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -1178,6 +1178,8 @@ export default store => {
           session.sendPlayerPronouns(payload);
         } else if (payload.property === "handRaised") {
           session.sendHandRaised(payload);
+        } else if (payload.property === "alignment") {
+          // ST-only: alignment is never broadcast — visible to ST and self only
         } else {
           session.sendPlayer(payload);
         }


### PR DESCRIPTION
- Added a button for the Storyteller and players to toggle the alignment of players.

- Good/Evil Alignment Toggle (new feature)
-- Seated players and the Storyteller can now privately annotate player alignment during a game.

- Storyteller view
-- A small circle button appears on each player token (top-right, matching the Night Order circle sizing and responsive scaling).
-- Clicking cycles alignment: Townsfolk/Outsider toggle evil → null; Minion/Demon toggle good → null; Traveler cycles good → evil → null.
-- A colour overlay (mix-blend-mode: color) tints the token blue (good) or red (evil).
-- ST alignment state is stored in Vuex and not transmitted via socket.

- Seated player view
-- Alignment buttons are visible on all player tokens — clicking records a private, local-only annotation for that token.
-- Annotations are stored in localStorage keyed by localAlignment_{playerId}_{targetPlayerId} — never transmitted through the socket.
-- Own token button is always visible; other tokens' buttons appear only when annotated (good/evil set), or on hover when neutral.
-- When a seated player has annotated their own token, the radiant pulsing glow behind their character token overrides the team colour: good → townsfolk blue, evil → demon red.

- Raise-hand button
-- The clickable raise-hand circle is hidden for seated players on other players' tokens.
-- The raised-hand image itself remains visible across all clients when a player raises their hand.
-- The ST can still click the button on behalf of any player.

- Build / Cross-platform Fix
-- Added cross-env devDependency so NODE_OPTIONS=--openssl-legacy-provider works on Windows without NODE_OPTIONS syntax errors.

- Bug Fixes:
-- String.substr() → String.slice() (deprecation) in socket.js.
-- Night Order circles and raise-hand emote raised to z-index: 5 to render above the alignment colour overlay.
-- Player context menu z-index: 50 — no longer drops behind other player tokens on hover.
-- TownSquare.vue emote em raised to z-index: 5.
-- Alignment button responsive sizing added to media.scss at <1200px and <992px breakpoints, matching the Night Order circle dimensions exactly.