### PR TITLE
Minor fix for reveal characters.

### DIFF
--- a/src/components/VictoryReveal.vue
+++ b/src/components/VictoryReveal.vue
@@ -244,7 +244,8 @@ export default {
     },
     trueAlignment(player) {
       if (!player.trueRole || !player.trueRole.team) return null;
-      if (["townsfolk", "outsider"].includes(player.trueRole.team)) return "good";
+      if (["townsfolk", "outsider"].includes(player.trueRole.team))
+        return "good";
       if (["minion", "demon"].includes(player.trueRole.team)) return "evil";
       return null;
     },

--- a/src/persona.json
+++ b/src/persona.json
@@ -1,10 +1,9 @@
 [
-  { "reminder": "Drunk" },
+  { "reminder": "Is the Drunk" },
   { "reminder": "Is the Philosopher" },
   { "reminder": "Is the Marionette" },
-  { "reminder": "EVIL Hannibal" },
-  { "reminder": "GOOD Hannibal" },
-  { "reminder": "Bad Omen, False, ~Evil" },
+  { "reminder": "Is the Hannibal" },
+  { "reminder": "Is the Bad Omen" },
   { "reminder": "Is the Blacksmith" },
   { "reminder": "Is Broken Toy" },
   { "reminder": "Is the Apprentice" },

--- a/src/roles.json
+++ b/src/roles.json
@@ -194,7 +194,7 @@
     "otherNight": 0,
     "otherNightReminder": "",
     "reminders": [],
-    "remindersGlobal": ["Drunk"],
+    "remindersGlobal": ["Is the Drunk"],
     "setup": true,
     "ability": "You do not know you are the Drunk. You think you are a Townsfolk character, but you are not."
   },
@@ -1733,8 +1733,8 @@
     "firstNightReminder": "Show the Grimoire to the Widow for as long as they need. The Widow points to a player. That player is poisoned. Wake a good player. Show the 'These characters are in play' card, then the Widow character token.",
     "otherNight": 0,
     "otherNightReminder": "",
-    "reminders": ["Poisoned"],
-    "remindersGlobal": ["Knows"],
+    "reminders": ["Poisoned", "Knows"],
+    "remindersGlobal": [],
     "setup": false,
     "ability": "On your 1st night, look at the Grimoire and choose a player: they are poisoned. 1 good player knows a Widow is in play."
   },
@@ -2309,7 +2309,7 @@
     "otherNight": 0,
     "otherNightReminder": "",
     "reminders": [],
-    "remindersGlobal": ["Bad Omen, False, ~Evil"],
+    "remindersGlobal": ["Is the Bad Omen"],
     "setup": false,
     "ability": "You do not know you are a Bad Omen. You think you are a Townsfolk, but you recieve false information. You might register as evil, even if dead."
   },
@@ -2375,7 +2375,7 @@
     "otherNight": 24,
     "otherNightReminder": "A player might die for each living Hannibal. Place the \"DEAD\" reminder token(s) next to the chosen player(s). They die. If a Hannibal dies, that night wake the player and inform them that they are a good Hannibal.",
     "reminders": [],
-    "remindersGlobal": ["Dead","EVIL Hannibal","GOOD Hannibal"],
+    "remindersGlobal": ["Dead","Is the Hannibal"],
     "setup": true,
     "ability": "You think you are a good character, but you are not. Minions learn 3 bluffs. Each night*, a player may die. The 1st Hannibal to die, becomes good. [+ Hannibal]"
   },

--- a/tests/unit/data/persona.spec.js
+++ b/tests/unit/data/persona.spec.js
@@ -15,14 +15,14 @@ describe("persona.json integrity", () => {
 
   test("every persona reminder exists in roles.json (reminders or remindersGlobal)", () => {
     const missing = personas
-      .map((p) => p.reminder)
-      .filter((r) => !allReminders.has(r));
+      .map(p => p.reminder)
+      .filter(r => !allReminders.has(r));
 
     if (missing.length > 0) {
       // eslint-disable-next-line no-console
       console.warn(
         "[persona.json] The following reminders are not found in any role in roles.json:\n" +
-          missing.map((r) => `  - "${r}"`).join("\n") +
+          missing.map(r => `  - "${r}"`).join("\n") +
           "\nUpdate persona.json or roles.json to keep them in sync."
       );
     }


### PR DESCRIPTION
There is a better implementation for the secondary character reveals, but that will have to come later.

This provides an immediate fix for an issue that confuses the Outsider character, Drunk, having a reminder as "Drunk" being mixed up with many other characters who have non-global reminders also labeled "Drunk". So, the reminder has been updated to "Is the Drunk", to make all the persona reminders start with "Is the" for consistency and avoiding the display bug.