### PR TITLE
Victory Bug Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 - Add a set of emotes that come from a players seated position
 -- probably disable emotes during an active votes/other important activites
 
+### Version 3.0.1
+- Added reveal for the true character tokens, such as Drunk, Marionette, etc.
+- Removed the Exit Presentation button and other minor fixes.
+- Added a special Good win reveal, so the dead Demon is revealed second to last.
+
 ### Version 3.0.0
 - Added a Storyteller Victory reveal screen & grimoire reveal!
 - Victory Screen System — Full Implementation

--- a/src/components/Player.vue
+++ b/src/components/Player.vue
@@ -798,7 +798,7 @@ export default {
   pointer-events: none;
   mix-blend-mode: color;
   z-index: 3;
-  transition: background-color 400ms ease, transform 200ms ease-in-out;
+  transition: transform 200ms ease-in-out;
   transform: perspective(400px) rotateY(0deg);
   backface-visibility: hidden;
 

--- a/src/components/VictoryModal.vue
+++ b/src/components/VictoryModal.vue
@@ -220,33 +220,74 @@ export default {
       const order = Array.from({ length: n }, (_, i) => i).sort(
         () => Math.random() - 0.5
       );
-      const featuredPos = alignment => {
-        const living = order.findIndex(
-          i =>
-            !snapshotPlayers[i].isDead &&
-            this.effectiveAlignment(snapshotPlayers[i]) === alignment
-        );
-        if (living !== -1) return living;
-        return order.findIndex(
-          i => this.effectiveAlignment(snapshotPlayers[i]) === alignment
-        );
-      };
-      const goodPos = featuredPos("good");
-      const evilPos = featuredPos("evil");
-      const candidates = [
-        { key: "good", pos: goodPos },
-        { key: "evil", pos: evilPos }
-      ]
-        .filter(p => p.pos !== -1)
-        .sort((a, b) => b.pos - a.pos);
-      const extracted = {};
-      for (const { key, pos } of candidates) {
-        extracted[key] = order.splice(pos, 1)[0];
+      // Good-victory cinematic override:
+      // If good wins AND there is a dead evil-aligned demon AND 2+ players are alive
+      // AND at least 1 alive good player exists → feature the dead demon then a
+      // living good player as the final two reveals (demon penultimate, good last).
+      const livingCount = snapshotPlayers.filter(p => !p.isDead).length;
+      const deadDemonIdx = order.findIndex(
+        i =>
+          snapshotPlayers[i].isDead &&
+          snapshotPlayers[i].role.team === "demon" &&
+          this.effectiveAlignment(snapshotPlayers[i]) === "evil"
+      );
+      const livingGoodIdx =
+        team === "good"
+          ? order.findIndex(
+              i =>
+                !snapshotPlayers[i].isDead &&
+                this.effectiveAlignment(snapshotPlayers[i]) === "good"
+            )
+          : -1;
+      const useCinematic =
+        team === "good" &&
+        deadDemonIdx !== -1 &&
+        livingCount >= 2 &&
+        livingGoodIdx !== -1;
+
+      if (useCinematic) {
+        // Extract in reverse-index order so splicing doesn't shift the other
+        const first = Math.max(deadDemonIdx, livingGoodIdx);
+        const second = Math.min(deadDemonIdx, livingGoodIdx);
+        const firstPlayer = order.splice(first, 1)[0];
+        const secondPlayer = order.splice(second, 1)[0];
+        // dead demon goes penultimate, living good player goes last
+        const penultimate = snapshotPlayers[firstPlayer].isDead
+          ? firstPlayer
+          : secondPlayer;
+        const last = snapshotPlayers[firstPlayer].isDead
+          ? secondPlayer
+          : firstPlayer;
+        order.push(penultimate, last);
+      } else {
+        const featuredPos = alignment => {
+          const living = order.findIndex(
+            i =>
+              !snapshotPlayers[i].isDead &&
+              this.effectiveAlignment(snapshotPlayers[i]) === alignment
+          );
+          if (living !== -1) return living;
+          return order.findIndex(
+            i => this.effectiveAlignment(snapshotPlayers[i]) === alignment
+          );
+        };
+        const goodPos = featuredPos("good");
+        const evilPos = featuredPos("evil");
+        const candidates = [
+          { key: "good", pos: goodPos },
+          { key: "evil", pos: evilPos }
+        ]
+          .filter(p => p.pos !== -1)
+          .sort((a, b) => b.pos - a.pos);
+        const extracted = {};
+        for (const { key, pos } of candidates) {
+          extracted[key] = order.splice(pos, 1)[0];
+        }
+        const losingTeam = team === "evil" ? "good" : "evil";
+        if (extracted[losingTeam] !== undefined)
+          order.push(extracted[losingTeam]);
+        if (extracted[team] !== undefined) order.push(extracted[team]);
       }
-      const losingTeam = team === "evil" ? "good" : "evil";
-      if (extracted[losingTeam] !== undefined)
-        order.push(extracted[losingTeam]);
-      if (extracted[team] !== undefined) order.push(extracted[team]);
 
       const snapshot = {
         players: snapshotPlayers,

--- a/src/components/VictoryReveal.vue
+++ b/src/components/VictoryReveal.vue
@@ -6,7 +6,6 @@
           {{ winningTeam === "good" ? "Good Wins!" : "Evil Wins!" }}
         </span>
         <span class="reveal-phase" v-if="!allRevealed">Revealing...</span>
-        <span class="exit-btn" @click="dismiss">Exit Presentation</span>
       </div>
 
       <div class="reveal-particle-layer" aria-hidden="true">
@@ -99,7 +98,7 @@ export default {
   },
   data() {
     return {
-      dismissed: false,
+      dismissed: true,
       revealedIndices: [],
       revealOrder: [],
       revealIdx: 0,
@@ -345,25 +344,6 @@ export default {
   animation: phase-blink 1.2s ease-in-out infinite;
 }
 
-.exit-btn {
-  position: absolute;
-  right: 20px;
-  top: 50%;
-  transform: translateY(-50%);
-  cursor: pointer;
-  font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.25);
-  padding: 4px 14px;
-  border-radius: 12px;
-  transition: color 200ms, border-color 200ms, background 200ms;
-  &:hover {
-    color: rgba(255, 255, 255, 0.9);
-    border-color: rgba(255, 255, 255, 0.6);
-    background: rgba(255, 255, 255, 0.08);
-  }
-}
-
 .reveal-particle-layer {
   position: absolute;
   inset: 0;
@@ -415,7 +395,7 @@ export default {
   left: 50%;
   transform: translate(-50%, -50%);
   z-index: 10;
-  font-size: 1rem;
+  font-size: 1.1rem;
   width: auto;
   padding: 0 6px;
   margin: 0;

--- a/src/roles.json
+++ b/src/roles.json
@@ -590,9 +590,11 @@
     "firstNightReminder": "If 7 or more players: Show the Lunatic a number of arbitrary 'Minions', players equal to the number of Minions in play. Show 3 character tokens of arbitrary good characters. If the token received by the Lunatic is a Demon that would wake tonight: Allow the Lunatic to do the Demon actions. Place their 'attack' markers. Wake the Demon. Show the Demon\u2019s real character token. Show them the Lunatic player. If the Lunatic attacked players: Show the real demon each marked player. Remove any Lunatic 'attack' markers.",
     "otherNight": 20,
     "otherNightReminder": "Allow the Lunatic to do the actions of the Demon. Place their 'attack' markers. If the Lunatic selected players: Wake the Demon. Show the 'attack' marker, then point to each marked player. Remove any Lunatic 'attack' markers.",
-    "reminders": ["Attack 1",
+    "remindersGlobal": ["Attack 1",
         "Attack 2",
         "Attack 3"],
+    "remindersPersonaGlobal": ["Is the Lunatic"],
+    "reminders": [],
     "setup": false,
     "ability": "You think you are a Demon, but you are not. The Demon knows who you are & who you choose at night."
   },

--- a/tests/unit/components/VictoryModal.spec.js
+++ b/tests/unit/components/VictoryModal.spec.js
@@ -480,4 +480,114 @@ describe("VictoryModal — revealGrimoire", () => {
     const last = snap[revealOrder[revealOrder.length - 1]];
     expect(["townsfolk", "outsider"]).toContain(last.role.team);
   });
+
+  // ── Cinematic good-victory override ──────────────────────────
+  describe("good victory cinematic override", () => {
+    // Conditions: good wins, dead EVIL-aligned demon exists, 2+ alive, 1+ alive good player
+    const cinematicPlayers = [
+      makePlayer("Alice", "townsfolk", null, false), // alive good
+      makePlayer("Bob", "townsfolk", null, false), // alive good (filler)
+      makePlayer("Carol", "demon", null, true) // dead demon (no alignment override → evil by team)
+    ];
+
+    it("places the dead demon penultimate and a living good player last", () => {
+      const mockCommit = jest.fn();
+      const ctx = makeCtx({
+        selectedCount: 2,
+        team: "good",
+        players: cinematicPlayers,
+        winners: [true, true, false],
+        $store: { commit: mockCommit },
+        close: jest.fn()
+      });
+      revealGrimoire.call(ctx);
+      const { revealOrder, players: snap } = mockCommit.mock.calls[0][1];
+      const last = snap[revealOrder[revealOrder.length - 1]];
+      const penultimate = snap[revealOrder[revealOrder.length - 2]];
+      expect(last.isDead).toBe(false);
+      expect(["townsfolk", "outsider"]).toContain(last.role.team);
+      expect(penultimate.isDead).toBe(true);
+      expect(penultimate.role.team).toBe("demon");
+    });
+
+    it("does not apply cinematic order for evil victory", () => {
+      const mockCommit = jest.fn();
+      const ctx = makeCtx({
+        selectedCount: 1,
+        team: "evil",
+        players: cinematicPlayers,
+        winners: [false, false, true],
+        $store: { commit: mockCommit },
+        close: jest.fn()
+      });
+      revealGrimoire.call(ctx);
+      const { revealOrder, players: snap } = mockCommit.mock.calls[0][1];
+      const last = snap[revealOrder[revealOrder.length - 1]];
+      // Standard rule: winning team (evil) goes last
+      expect(["minion", "demon"]).toContain(last.role.team);
+    });
+
+    it("does not apply cinematic order when no dead demon", () => {
+      const mockCommit = jest.fn();
+      const livingDemonPlayers = [
+        makePlayer("Alice", "townsfolk", null, false),
+        makePlayer("Bob", "townsfolk", null, false),
+        makePlayer("Carol", "demon", null, false) // alive demon — no cinematic
+      ];
+      const ctx = makeCtx({
+        selectedCount: 2,
+        team: "good",
+        players: livingDemonPlayers,
+        winners: [true, true, false],
+        $store: { commit: mockCommit },
+        close: jest.fn()
+      });
+      revealGrimoire.call(ctx);
+      const { revealOrder } = mockCommit.mock.calls[0][1];
+      // Just assert it completes and covers all players
+      expect(revealOrder).toHaveLength(livingDemonPlayers.length);
+    });
+
+    it("does not apply cinematic order when only 1 player alive", () => {
+      const mockCommit = jest.fn();
+      const oneAlivePlayers = [
+        makePlayer("Alice", "townsfolk", null, false), // the one alive good
+        makePlayer("Bob", "townsfolk", null, true), // dead
+        makePlayer("Carol", "demon", null, true) // dead demon
+      ];
+      const ctx = makeCtx({
+        selectedCount: 1,
+        team: "good",
+        players: oneAlivePlayers,
+        winners: [true, false, false],
+        $store: { commit: mockCommit },
+        close: jest.fn()
+      });
+      revealGrimoire.call(ctx);
+      const { revealOrder } = mockCommit.mock.calls[0][1];
+      expect(revealOrder).toHaveLength(oneAlivePlayers.length);
+    });
+
+    it("does not apply cinematic order when dead demon is good-aligned (e.g. Hannibal)", () => {
+      const mockCommit = jest.fn();
+      const goodDemonPlayers = [
+        makePlayer("Alice", "townsfolk", null, false), // alive good
+        makePlayer("Bob", "townsfolk", null, false), // alive good (filler)
+        makePlayer("Carol", "demon", "good", true) // dead demon but good alignment
+      ];
+      const ctx = makeCtx({
+        selectedCount: 2,
+        team: "good",
+        players: goodDemonPlayers,
+        winners: [true, true, true],
+        $store: { commit: mockCommit },
+        close: jest.fn()
+      });
+      revealGrimoire.call(ctx);
+      const { revealOrder, players: snap } = mockCommit.mock.calls[0][1];
+      // Cinematic should not fire — last player should be good (standard rule) but NOT the dead demon
+      const last = snap[revealOrder[revealOrder.length - 1]];
+      expect(last.isDead).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
**Summary**
- Stale reveal overlay blocked all clicks (alignment buttons etc.) after session handoff — fixed by defaulting dismissed: true
- Good victory reveal order now holds the dead evil demon and a living good player back as the dramatic final two tokens
- Alignment toggle to evil no longer fades through red — now instant, matching toggle to good
- "Exit Presentation" button removed from reveal screen, superseded by the centered Close button
- Close button on reveal screen increased 10% in size